### PR TITLE
dts: vendor-prefixes: add hid

### DIFF
--- a/dts/bindings/vendor-prefixes.txt
+++ b/dts/bindings/vendor-prefixes.txt
@@ -180,6 +180,7 @@ gw	Gateworks Corporation
 hannstar	HannStar Display Corporation
 haoyu	Haoyu Microelectronic Co. Ltd.
 hardkernel	Hardkernel Co., Ltd
+hid	HID Global
 hideep	HiDeep Inc.
 himax	Himax Technologies, Inc.
 hisilicon	Hisilicon Limited.


### PR DESCRIPTION
We would like to aquire hid binding in zephyr. 
'hid' is not present in the Linux.
    
Signed-off-by: Zwierz, Marcin <marcin.zwierz@hidglobal.com>